### PR TITLE
Adding stdout output (alternate method)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 *.exe
 *.out
 *.app
+
+# Linux Executable
+ww2ogg

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ You can also specify an output file with `-o`, as in
 
 `ww2ogg input.ogg -o output.ogg`
 
+To output the file to stdout (such as to pipe it to revorb or other
+audio-processing utilities), use `-o -`, as in
+
+`ww2ogg input.ogg -o - | revorb - output.ogg`
+
 
 Troubleshooting
 --------------------------------------------------------------------------------

--- a/src/ww2ogg.cpp
+++ b/src/ww2ogg.cpp
@@ -10,6 +10,9 @@
 #define _isatty isatty
 #define _fileno fileno
 #endif
+#ifdef __MINGW32__
+#define <fcntl.h>
+#endif
 
 using namespace std;
 

--- a/src/ww2ogg.cpp
+++ b/src/ww2ogg.cpp
@@ -51,11 +51,14 @@ void header(void)
 
 void usage(void)
 {
-    header();
     cout << endl;
+    header();
     cout << "usage: ww2ogg input.wav [-o output.ogg] [--inline-codebooks] [--full-setup]" << endl <<
             "                        [--mod-packets | --no-mod-packets]" << endl <<
-            "                        [--pcb packed_codebooks.bin] [--quiet]" << endl << endl;
+            "                        [--pcb packed_codebooks.bin] [--quiet]" << endl <<
+            endl <<
+            "Use \"-o -\" to send the ogg file to stdout.  This will also" << endl <<
+            "imply \"--quiet\"." << endl << endl;
 }
 
 int main(int argc, char **argv)

--- a/src/ww2ogg.cpp
+++ b/src/ww2ogg.cpp
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 
         if (opt.get_to_stdout())
         {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32) || defined(_WIN64) || defined(__MINGW32__)
             _setmode(_fileno(stdout),  _O_BINARY);
 #endif
             ww.generate_ogg(cout);

--- a/src/ww2ogg.cpp
+++ b/src/ww2ogg.cpp
@@ -5,6 +5,11 @@
 #include "wwriff.h"
 #include "stdint.h"
 #include "errors.h"
+#ifdef __unix__
+#include <unistd.h>
+#define _isatty isatty
+#define _fileno fileno
+#endif
 
 using namespace std;
 
@@ -16,13 +21,17 @@ class ww2ogg_options
     bool inline_codebooks;
     bool full_setup;
     ForcePacketFormat force_packet_format;
+    bool quiet;
+    bool to_stdout;
 public:
     ww2ogg_options(void) : in_filename(""),
                            out_filename(""),
                            codebooks_filename("packed_codebooks.bin"),
                            inline_codebooks(false),
                            full_setup(false),
-                           force_packet_format(kNoForcePacketFormat)
+                           force_packet_format(kNoForcePacketFormat),
+                           quiet(false),
+                           to_stdout(false)
       {}
     void parse_args(int argc, char **argv);
     const string& get_in_filename(void) const {return in_filename;}
@@ -31,19 +40,26 @@ public:
     bool get_inline_codebooks(void) const {return inline_codebooks;}
     bool get_full_setup(void) const {return full_setup;}
     ForcePacketFormat get_force_packet_format(void) const {return force_packet_format;}
+    bool get_quiet(void) const {return quiet;}
+    bool get_to_stdout(void) const {return to_stdout;}
 };
+
+void header(void)
+{
+    cout << "Audiokinetic Wwise RIFF/RIFX Vorbis to Ogg Vorbis converter " VERSION " by hcs" << endl << endl;
+}
 
 void usage(void)
 {
+    header();
     cout << endl;
     cout << "usage: ww2ogg input.wav [-o output.ogg] [--inline-codebooks] [--full-setup]" << endl <<
             "                        [--mod-packets | --no-mod-packets]" << endl <<
-            "                        [--pcb packed_codebooks.bin]" << endl << endl;
+            "                        [--pcb packed_codebooks.bin] [--quiet]" << endl << endl;
 }
 
 int main(int argc, char **argv)
 {
-    cout << "Audiokinetic Wwise RIFF/RIFX Vorbis to Ogg Vorbis converter " VERSION " by hcs" << endl << endl;
 
     ww2ogg_options opt;
 
@@ -59,9 +75,17 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    if (!opt.get_quiet())
+    {
+        header();
+    }
+
     try
     {
-        cout << "Input: " << opt.get_in_filename() << endl;
+        if (!opt.get_quiet())
+        {
+            cout << "Input: " << opt.get_in_filename() << endl;
+        }
         Wwise_RIFF_Vorbis ww(opt.get_in_filename(),
                 opt.get_codebooks_filename(),
                 opt.get_inline_codebooks(),
@@ -69,23 +93,42 @@ int main(int argc, char **argv)
                 opt.get_force_packet_format()
                 );
 
-        ww.print_info();
-        cout << "Output: " << opt.get_out_filename() << endl;
+        if (!opt.get_quiet())
+        {
+            ww.print_info();
+        }
 
-        ofstream of(opt.get_out_filename().c_str(), ios::binary);
-        if (!of) throw File_open_error(opt.get_out_filename());
+        if (opt.get_to_stdout())
+        {
+#if defined(_WIN32) || defined(_WIN64)
+            _setmode(_fileno(stdout),  _O_BINARY);
+#endif
+            ww.generate_ogg(cout);
+        }
+        else
+        {
+            if (!opt.get_quiet())
+            {
+                cout << "Output: " << opt.get_out_filename() << endl;
+            }
+            ofstream of(opt.get_out_filename().c_str(), ios::binary);
+            if (!of) throw File_open_error(opt.get_out_filename());
+            ww.generate_ogg(of);
+        }
 
-        ww.generate_ogg(of);
-        cout << "Done!" << endl << endl;
+        if (!opt.get_quiet())
+        {
+            cout << "Done!" << endl << endl;
+        }
     }
     catch (const File_open_error& fe)
     {
-        cout << fe << endl;
+        cerr << fe << endl;
         return 1;
     }
     catch (const Parse_error& pe)
     {
-        cout << pe << endl;
+        cerr << pe << endl;
         return 1;
     }
 
@@ -105,12 +148,21 @@ void ww2ogg_options::parse_args(int argc, char ** argv)
                 throw Argument_error("-o needs an option");
             }
 
-            if (set_output)
+            if (set_output or to_stdout)
             {
                 throw Argument_error("only one output file at a time");
             }
 
             out_filename = argv[++i];
+            if (out_filename == "-")
+            {
+                if (_isatty(_fileno(stdout)))
+                {
+                    throw Argument_error("STDOUT output is not supported when on a TTY");
+                }
+                to_stdout = true;
+                quiet = true;
+            }
             set_output = true;
         }
         else if (!strcmp(argv[i], "--inline-codebooks"))
@@ -149,6 +201,12 @@ void ww2ogg_options::parse_args(int argc, char ** argv)
             }
 
             codebooks_filename = argv[++i];
+        }
+        else if (!strcmp(argv[i], "--quiet"))
+        {
+            // don't output any status messages to stdout (will be
+            // forced active if our output is stdout)
+            quiet = true;
         }
         else
         {

--- a/src/ww2ogg.cpp
+++ b/src/ww2ogg.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
     }
     catch (const Argument_error& ae)
     {
-        cout << ae << endl;
+        cerr << ae << endl;
 
         usage();
         return 1;

--- a/src/wwriff.cpp
+++ b/src/wwriff.cpp
@@ -1017,7 +1017,7 @@ void Wwise_RIFF_Vorbis::generate_ogg_header(Bit_oggstream& os, bool * & mode_blo
     }
 }
 
-void Wwise_RIFF_Vorbis::generate_ogg(ofstream& of)
+void Wwise_RIFF_Vorbis::generate_ogg(ostream& of)
 {
     Bit_oggstream os(of);
 

--- a/src/wwriff.h
+++ b/src/wwriff.h
@@ -75,7 +75,7 @@ public:
 
     void print_info(void);
 
-    void generate_ogg(ofstream& of);
+    void generate_ogg(ostream& of);
     void generate_ogg_header(Bit_oggstream& os, bool * & mode_blockflag, int & mode_bits);
     void generate_ogg_header_with_triad(Bit_oggstream& os);
 };


### PR DESCRIPTION
I was looking to script this together with revorb and came across #8, which adds STDOUT output to ww2ogg.  It looks like that one never got fully cleaned up, though, and I'd prefer a different implementation anyway, so I've done up my own PR.

What this does is:
1. Adds a `--quiet` option which silences all "status" type messages
2. Allows using `-` as the output file option, which forces the use of `--quiet`
3. Status output (when not using `--quiet`) remains on stdout, rather than switching to stderr as the other PR does.
4. Checks `isatty()` as requested in that other PR

I've introduced some OS-specific tweaks to support some of this -- namely, Linux machines will need to include `unistd.h` and do some `#define` shenanigans to be able to use `_isatty` and `_fileno`, as they're known on the Windows side.  The other PR implied that MinGW32 needed `fcntl.h` for `_O_OUTPUT` as well, so that's there.  The call to `_setmode` (to ensure that stdout is handled as binary data) doesn't need to be done on Linux because Linux doesn't distinguish between binary + text on the standard streams (and doesn't define `_setmode`) anyway.

This has received **no** testing on Windows, w/ MinGW or not, so I can't vouch for that.  It also doesn't pull the `--quiet` functionality into those other commented `cout` instances throughout the code, since that would involve passing some more vars around and it didn't seem worth it.  I *have* tested this with revorb, and that works great.

I did verify that the output is identical in a variety of circumstances, and checked it versus the unpatched output as well:

Auto-filename:

    $ ./ww2ogg 1000168723.wem
    Audiokinetic Wwise RIFF/RIFX Vorbis to Ogg Vorbis converter 0.24 by hcs

    Input: 1000168723.wem
    RIFF WAVE 2 channels 48000 Hz 238352 bps
    20209 samples
    - 2 byte packet headers, no granule
    - stripped setup header
    - external codebooks (packed_codebooks.bin)
    - modified Vorbis packets
    Output: 1000168723.ogg
    Done!

Specified filename:

    $ ./ww2ogg -o test1.ogg 1000168723.wem
    Audiokinetic Wwise RIFF/RIFX Vorbis to Ogg Vorbis converter 0.24 by hcs

    Input: 1000168723.wem
    RIFF WAVE 2 channels 48000 Hz 238352 bps
    20209 samples
    - 2 byte packet headers, no granule
    - stripped setup header
    - external codebooks (packed_codebooks.bin)
    - modified Vorbis packets
    Output: test1.ogg
    Done!

Quiet output:

    $ ./ww2ogg -o test2.ogg --quiet 1000168723.wem

Redirected to file manually:

    $ ./ww2ogg -o - 1000168723.wem > test3.ogg

Checksums:

    $ sha256sum *.ogg
    18bd61b76089691ae26deac21cd781454fb2a54d2043531f256dddc910342988  1000168723.ogg
    18bd61b76089691ae26deac21cd781454fb2a54d2043531f256dddc910342988  test1.ogg
    18bd61b76089691ae26deac21cd781454fb2a54d2043531f256dddc910342988  test2.ogg
    18bd61b76089691ae26deac21cd781454fb2a54d2043531f256dddc910342988  test3.ogg

Errors still display when redirecting:

    $ ./ww2ogg -o - invalid_input > test4.ogg
    Parse error: missing RIFF
    $ cat test4.ogg
    $

Refuses to output to stdout when on a TTY (also shows some extra `usage()` text):

    $ ./ww2ogg -o - 1000168723.wem
    Argument error: STDOUT output is not supported when on a TTY

    Audiokinetic Wwise RIFF/RIFX Vorbis to Ogg Vorbis converter 0.24 by hcs

    usage: ww2ogg input.wav [-o output.ogg] [--inline-codebooks] [--full-setup]
                            [--mod-packets | --no-mod-packets]
                            [--pcb packed_codebooks.bin] [--quiet]

    Use "-o -" to send the ogg file to stdout.  This will also
    imply "--quiet".

Anyway, lots of text.  Let me know if you want any changes or a different implementation, etc!